### PR TITLE
Fix compile errors, use more idiomatic Rust, make interface more user-friendly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,36 +9,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.57"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "anstyle"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
+ "utf8parse",
 ]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "autocfg"
@@ -48,9 +80,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base-x"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19a4937b4fbd3fe3379793130e42060d10627a360f2127802b10b87e7baf74"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "bitflags"
@@ -59,22 +91,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bumpalo"
-version = "3.9.1"
+name = "bitflags"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "bstr"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytemuck"
-version = "1.9.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdead85bdec19c194affaeeb670c0e41fe23de31459efd1c174d049269cf02cc"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cc"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -84,42 +142,44 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.1.14"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535434c063ced786eb04aaf529308092c5ab60889e8fe24275d15de07b01fa97"
+checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
 dependencies = [
- "atty",
- "bitflags",
+ "clap_builder",
  "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap",
- "lazy_static",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "color_quant"
@@ -128,14 +188,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
-name = "colored"
-version = "2.0.0"
+name = "colorchoice"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "colored"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
- "atty",
+ "is-terminal",
  "lazy_static",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -151,16 +217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "deflate"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
-dependencies = [
- "adler32",
- "byteorder",
 ]
 
 [[package]]
@@ -240,61 +296,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
-name = "flate2"
-version = "1.0.23"
+name = "errno"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
- "cfg-if",
- "crc32fast",
+ "errno-dragonfly",
  "libc",
- "miniz_oxide 0.5.1",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
 name = "gif"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a7187e78088aead22ceedeee99779455b23fc231fe13ec443f99bb71694e5b"
+checksum = "80792593675e051cf94a4b111980da2ba60d4a83e43e0048c5693baab3977045"
 dependencies = [
  "color_quant",
  "weezl",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "heck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "image"
-version = "0.23.14"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1"
+checksum = "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
  "gif",
  "jpeg-decoder",
- "num-iter",
- "num-rational 0.3.2",
+ "num-rational",
  "num-traits",
  "png",
  "tiff",
@@ -314,13 +388,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.8.1"
+name = "is-terminal"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "autocfg",
- "hashbrown",
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -331,21 +406,21 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.1.22"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
+checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -358,24 +433,27 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.125"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
-dependencies = [
- "cfg-if",
-]
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lopdf"
@@ -403,43 +481,25 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.3.7"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
- "autocfg",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
-dependencies = [
- "adler",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "num"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
- "num-rational 0.4.0",
+ "num-rational",
  "num-traits",
 ]
 
@@ -456,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fbc387afefefd5e9e39493299f3069e14a140dd34dc19b4c1c1a8fddb6a790"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
 ]
@@ -486,20 +546,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-bigint",
@@ -509,18 +558,18 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.0.0"
+name = "once_cell"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -533,27 +582,31 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.16.8"
+version = "0.17.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
+checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
- "deflate",
- "miniz_oxide 0.3.7",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
 name = "pom"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e2192780e9f8e282049ff9bffcaa28171e1cb0844f49ed5374e518ae6024ec"
+checksum = "5c2d73a5fe10d458e77534589512104e5aa8ac480aa9ac30b74563274235cce4"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "printpdf"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382011eb582243f0c84620293a50d6a2d142494ed156463511ab5c44580e60fd"
+checksum = "6b61f0c6672a5507f0557c50c2263abc54fecc2a4c0ca56499be1396679a686c"
 dependencies = [
  "image",
  "js-sys",
@@ -563,58 +616,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.5"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -623,9 +664,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rustc_version"
@@ -637,10 +678,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.9"
+name = "rustix"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "semver"
@@ -659,28 +713,28 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.80"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.9",
  "ryu",
  "serde",
 ]
@@ -699,6 +753,12 @@ name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "standback"
@@ -733,7 +793,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_derive",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -749,7 +809,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -766,38 +826,34 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.92"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
+name = "syn"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
- "winapi-util",
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "tiff"
-version = "0.6.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a53f4706d65497df0c4349241deddf35f84cee19c87ed86ea8ca590f4464437"
+checksum = "6d172b0f4d3fba17ba89811858b9d3d97f928aece846475bbda076ca46736211"
 dependencies = [
+ "flate2",
  "jpeg-decoder",
- "miniz_oxide 0.4.4",
  "weezl",
 ]
 
@@ -836,7 +892,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "standback",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -846,10 +902,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae2f58a822f08abdaf668897e96a5656fe72f5a9ce66422423e8849384872e6"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "version_check"
@@ -859,9 +921,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -869,24 +931,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -894,28 +956,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "weezl"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c97e489d8f836838d497091de568cf16b117486d529ec5579233521065bd5e4"
+checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "winapi"
@@ -934,16 +996,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -201,7 +201,20 @@ checksum = "2674ec482fbc38012cf31e6c42ba0177b431a0cb6f15fe40efa5aab1bda516f6"
 dependencies = [
  "is-terminal",
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "console"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -230,6 +243,12 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding"
@@ -303,7 +322,7 @@ checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -358,6 +377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
+name = "human-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "140a09c9305e6d5e557e2ed7cbc68e05765a7d4213975b87cb04920689cc6219"
+
+[[package]]
 name = "image"
 version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -382,9 +407,33 @@ dependencies = [
  "byteorder",
  "clap",
  "colored",
+ "human-sort",
+ "indicatif",
  "num",
  "printpdf",
  "regex",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b297dc40733f23a0e52728a58fa9489a5b7638a324932de16b41adc3ef80730"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -395,7 +444,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -566,6 +615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,6 +656,12 @@ checksum = "5c2d73a5fe10d458e77534589512104e5aa8ac480aa9ac30b74563274235cce4"
 dependencies = [
  "bstr",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f32154ba0af3a075eefa1eda8bb414ee928f62303a54ea85b8d6638ff1a6ee9e"
 
 [[package]]
 name = "printpdf"
@@ -687,7 +748,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -908,6 +969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1003,11 +1070,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -1016,14 +1107,20 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1033,9 +1130,21 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1045,9 +1154,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1057,9 +1178,21 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,24 +19,23 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
- "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
 
 [[package]]
 name = "anstyle-parse"
@@ -58,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -127,9 +126,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
 ]
@@ -142,9 +141,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.23"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
+checksum = "1d5f1946157a96594eb2d2c10eb7ad9a2b27518cb3000209dec700c35df9197d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -153,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.23"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
+checksum = "78116e32a042dd73c2901f0dc30790d20ff3447f3e3472fad359e8c3d282bcd6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -165,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.12"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
+checksum = "c9fd1a5729c4548118d7d70ff234a44868d00489a4b6597b0b020918a0e91a1a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -177,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "color_quant"
@@ -554,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -659,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32154ba0af3a075eefa1eda8bb414ee928f62303a54ea85b8d6638ff1a6ee9e"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "printpdf"
@@ -774,15 +773,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.183"
+version = "1.0.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "30a7fe14252655bd1e578af19f5fa00fe02fd0013b100ca6b49fde31c41bae4c"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "e46b2a6ca578b3f1d4501b12f78ed4692006d79d82a1a7c561c12dbc3d625eb8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,11 @@ regex = "1"
 colored = "2"
 num = "0.4"
 byteorder = "1.4.3"
+indicatif = "0.17.6"
+human-sort = "0.2.2"
 
 [profile.release]
+codegen-units = 1
 opt-level = 3
 lto = true
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,14 @@ exclude = ["assets/*"]
 
 [dependencies]
 printpdf = { version = "0.5", features = ["embedded_images"] }
-clap = { version = "3.1.14", features = ["derive"] }
-anyhow = "1.0.57"
+clap = { version = "4.3", features = ["derive"] }
+anyhow = "1.0"
 regex = "1"
 colored = "2"
 num = "0.4"
 byteorder = "1.4.3"
+
+[profile.release]
+opt-level = 3
+lto = true
+strip = true

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,13 +1,18 @@
+use std::path::PathBuf;
+
 use clap::Parser;
 
+use crate::pagesize::PageSizeInMm;
+
 #[derive(Parser, Debug)]
-#[clap(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None)]
 pub struct Args {
-    pub input: Vec<String>,
-
-    #[clap(short, long, default_value = "test_working.pdf")]
-    pub output: String,
-
-    #[clap(short, long)]
-    pub pagesize: Option<String>,
+    /// The input file(s)
+    pub input: Vec<PathBuf>,
+    /// The output file
+    #[arg(short, long, default_value = "output.pdf")]
+    pub output: PathBuf,
+    /// The page size of the output file
+    #[arg(short, long)]
+    pub pagesize: Option<PageSizeInMm>,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -12,7 +12,7 @@ pub struct Args {
     /// The output file
     #[arg(short, long, default_value = "output.pdf")]
     pub output: PathBuf,
-    /// The page size of the output file
+    /// The page size of the output file (for landscape add "^T") [A0-A6, B0-B6, Jb0-Jb6, Letter, Legal, Tabloid]
     #[arg(short, long)]
     pub pagesize: Option<PageSizeInMm>,
     /// Sort the input files by human rules (e.g. 1, 2, 10 instead of 1, 10, 2)

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,4 +15,7 @@ pub struct Args {
     /// The page size of the output file
     #[arg(short, long)]
     pub pagesize: Option<PageSizeInMm>,
+    /// Sort the input files by human rules (e.g. 1, 2, 10 instead of 1, 10, 2)
+    #[arg(short = 's', long = "human-sorting")]
+    pub human_sorting: bool,
 }

--- a/src/image/alpha_remover.rs
+++ b/src/image/alpha_remover.rs
@@ -1,27 +1,26 @@
+use std::mem;
+
 use num::{traits::bounds::UpperBounded, FromPrimitive, ToPrimitive};
 use printpdf::{image_crate::ColorType, ColorSpace, Image};
 
-fn remove_alpha_from_4_channel<T>(image_data: &[T]) -> Vec<T>
+fn remove_alpha_from_4_channel<T>(image_data: Vec<T>) -> Vec<T>
 where
     T: Clone + ToPrimitive + FromPrimitive + UpperBounded,
 {
     let max_value = T::max_value().to_f64().unwrap();
-    let new_image_data = image_data
+    image_data
         .chunks(4)
-        .map(|rgba| {
-            let first = rgba[0].to_f64().unwrap();
-            let second = rgba[1].to_f64().unwrap();
-            let third = rgba[2].to_f64().unwrap();
+        .flat_map(|rgba| {
+            let red = rgba[0].to_f64().unwrap();
+            let green = rgba[1].to_f64().unwrap();
+            let blue = rgba[2].to_f64().unwrap();
             let alpha = rgba[3].to_f64().unwrap() / max_value;
-            let new_first = T::from_f64((1.0 - alpha) * max_value + alpha * first).unwrap();
-            let new_second = T::from_f64((1.0 - alpha) * max_value + alpha * second).unwrap();
-            let new_third = T::from_f64((1.0 - alpha) * max_value + alpha * third).unwrap();
+            let new_first = T::from_f64((1.0 - alpha) * max_value + alpha * red).unwrap();
+            let new_second = T::from_f64((1.0 - alpha) * max_value + alpha * green).unwrap();
+            let new_third = T::from_f64((1.0 - alpha) * max_value + alpha * blue).unwrap();
             [new_first, new_second, new_third]
         })
-        .collect::<Vec<[T; 3]>>()
-        .concat();
-
-    new_image_data
+        .collect()
 }
 
 pub trait RemoveAlpha {
@@ -32,7 +31,8 @@ impl RemoveAlpha for Image {
     fn remove_alpha(&mut self, color_type: ColorType) {
         match color_type {
             ColorType::Rgba8 => {
-                let new_image_data = remove_alpha_from_4_channel(&self.image.image_data);
+                let new_image_data =
+                    remove_alpha_from_4_channel(mem::take(&mut self.image.image_data));
                 self.image.image_data = new_image_data;
                 self.image.color_space = ColorSpace::Rgb;
             }
@@ -41,19 +41,14 @@ impl RemoveAlpha for Image {
                     .image
                     .image_data
                     .chunks(2)
-                    .map(|arr| {
-                        let x1 = arr[0];
-                        let x2 = arr[1];
-                        (x1 as u16) * 256 + (x2 as u16)
-                    })
+                    .map(|arr| u16::from_be_bytes([arr[0], arr[1]]))
                     .collect();
-                let new_u16_image_data = remove_alpha_from_4_channel(&u16_image_data);
+                let new_u16_image_data = remove_alpha_from_4_channel(u16_image_data);
 
                 let new_u8_image_data = new_u16_image_data
                     .into_iter()
-                    .map(|num| [(num / 256) as u8, (num % 256) as u8])
-                    .collect::<Vec<[u8; 2]>>()
-                    .concat();
+                    .flat_map(u16::to_be_bytes)
+                    .collect();
 
                 self.image.image_data = new_u8_image_data;
                 self.image.color_space = ColorSpace::Rgb;

--- a/src/image/image_reader.rs
+++ b/src/image/image_reader.rs
@@ -1,22 +1,21 @@
+use std::{fs::File, path::Path};
+
 use anyhow::{anyhow, Result};
 use colored::Colorize;
-
-use std::fs::File;
-
 use image_crate::codecs::{bmp::BmpDecoder, jpeg::JpegDecoder, png::PngDecoder};
 use printpdf::{
     image_crate::{self, ColorType, ImageDecoder},
     Image,
 };
 
-enum ImageType {
+enum ImageType<'a> {
     Bmp,
     Jpeg,
     Png,
-    Unsupported,
+    Unsupported(&'a str),
 }
 
-fn get_image_type(img_file_name: &str) -> ImageType {
+fn get_image_type(img_file_name: &str) -> ImageType<'_> {
     let extension_option = img_file_name.split('.').last();
     if let Some(extension) = extension_option {
         return match extension.to_lowercase().as_str() {
@@ -24,16 +23,17 @@ fn get_image_type(img_file_name: &str) -> ImageType {
             "png" => ImageType::Png,
             "jpg" => ImageType::Jpeg,
             "jpeg" => ImageType::Jpeg,
-            _ => ImageType::Unsupported,
+            _ => ImageType::Unsupported(img_file_name),
         };
     }
-    ImageType::Unsupported
+    ImageType::Unsupported(img_file_name)
 }
 
-pub fn read_image_from_file(img_file_name: &str) -> Result<(ColorType, Image)> {
+pub fn read_image_from_file<P: AsRef<Path>>(img_file_name: P) -> Result<(ColorType, Image)> {
+    let img_file_name = img_file_name.as_ref();
     let mut img_file = File::open(img_file_name)?;
 
-    match get_image_type(img_file_name) {
+    match get_image_type(&img_file_name.to_string_lossy()) {
         ImageType::Bmp => {
             let bmp_decoder = BmpDecoder::new(&mut img_file)?;
             let color_type = bmp_decoder.color_type();
@@ -52,7 +52,7 @@ pub fn read_image_from_file(img_file_name: &str) -> Result<(ColorType, Image)> {
             let image = Image::try_from(jpeg_decoder)?;
             Ok((color_type, image))
         }
-        ImageType::Unsupported => Err(anyhow!(
+        ImageType::Unsupported(img_file_name) => Err(anyhow!(
             "Format of image file {} is not supported. We only support BMP, PNG, JPEG and SVG",
             img_file_name.blue().underline()
         )),

--- a/src/image/image_reader.rs
+++ b/src/image/image_reader.rs
@@ -53,7 +53,7 @@ pub fn read_image_from_file<P: AsRef<Path>>(img_file_name: P) -> Result<(ColorTy
             Ok((color_type, image))
         }
         ImageType::Unsupported(img_file_name) => Err(anyhow!(
-            "Format of image file {} is not supported. We only support BMP, PNG, JPEG and SVG",
+            "Format of image file {} is not supported. We only support BMP, PNG and JPEG",
             img_file_name.blue().underline()
         )),
     }

--- a/src/image/image_reader.rs
+++ b/src/image/image_reader.rs
@@ -10,49 +10,49 @@ use printpdf::{
 };
 
 enum ImageType {
-    BMP,
-    JPEG,
-    PNG,
-    UNSUPPORTED,
+    Bmp,
+    Jpeg,
+    Png,
+    Unsupported,
 }
 
 fn get_image_type(img_file_name: &str) -> ImageType {
     let extension_option = img_file_name.split('.').last();
     if let Some(extension) = extension_option {
         return match extension.to_lowercase().as_str() {
-            "bmp" => ImageType::BMP,
-            "png" => ImageType::PNG,
-            "jpg" => ImageType::JPEG,
-            "jpeg" => ImageType::JPEG,
-            _ => ImageType::UNSUPPORTED,
+            "bmp" => ImageType::Bmp,
+            "png" => ImageType::Png,
+            "jpg" => ImageType::Jpeg,
+            "jpeg" => ImageType::Jpeg,
+            _ => ImageType::Unsupported,
         };
     }
-    ImageType::UNSUPPORTED
+    ImageType::Unsupported
 }
 
 pub fn read_image_from_file(img_file_name: &str) -> Result<(ColorType, Image)> {
-    let mut img_file = File::open(&img_file_name)?;
+    let mut img_file = File::open(img_file_name)?;
 
     match get_image_type(img_file_name) {
-        ImageType::BMP => {
+        ImageType::Bmp => {
             let bmp_decoder = BmpDecoder::new(&mut img_file)?;
             let color_type = bmp_decoder.color_type();
             let image = Image::try_from(bmp_decoder)?;
-            return Ok((color_type, image));
+            Ok((color_type, image))
         }
-        ImageType::PNG => {
+        ImageType::Png => {
             let png_decoder = PngDecoder::new(&mut img_file)?;
             let color_type = png_decoder.color_type();
             let image = Image::try_from(png_decoder)?;
-            return Ok((color_type, image));
+            Ok((color_type, image))
         }
-        ImageType::JPEG => {
+        ImageType::Jpeg => {
             let jpeg_decoder = JpegDecoder::new(&mut img_file)?;
             let color_type = jpeg_decoder.color_type();
             let image = Image::try_from(jpeg_decoder)?;
-            return Ok((color_type, image));
+            Ok((color_type, image))
         }
-        ImageType::UNSUPPORTED => Err(anyhow!(
+        ImageType::Unsupported => Err(anyhow!(
             "Format of image file {} is not supported. We only support BMP, PNG, JPEG and SVG",
             img_file_name.blue().underline()
         )),

--- a/src/image/image_reader.rs
+++ b/src/image/image_reader.rs
@@ -21,8 +21,7 @@ fn get_image_type(img_file_name: &str) -> ImageType<'_> {
         return match extension.to_lowercase().as_str() {
             "bmp" => ImageType::Bmp,
             "png" => ImageType::Png,
-            "jpg" => ImageType::Jpeg,
-            "jpeg" => ImageType::Jpeg,
+            "jpg" | "jpeg" => ImageType::Jpeg,
             _ => ImageType::Unsupported(img_file_name),
         };
     }

--- a/src/image/image_transform.rs
+++ b/src/image/image_transform.rs
@@ -5,10 +5,13 @@ use crate::pagesize::PageSizeInMm;
 use crate::image::image_x_object::get_image_dimension_in_mm;
 
 pub fn get_image_transform_for_page_size(
-    page_size: &PageSizeInMm,
+    pagesize: PageSizeInMm,
     image_object: &ImageXObject,
 ) -> ImageTransform {
-    let PageSizeInMm(page_size_width, page_size_height) = page_size;
+    let PageSizeInMm {
+        width: page_size_width,
+        height: page_size_height,
+    } = pagesize;
     let page_size_ratio = page_size_width / page_size_height;
 
     let (image_width, image_height) = get_image_dimension_in_mm(image_object);
@@ -18,7 +21,7 @@ pub fn get_image_transform_for_page_size(
         let scale_based_on_height = page_size_height / image_height;
         let new_image_width = image_width * scale_based_on_height;
         return ImageTransform {
-            translate_x: Some(Mm((page_size_width - new_image_width) / 2.0)),
+            translate_x: Some((page_size_width - new_image_width) / 2.0),
             translate_y: Some(Mm(0.0)),
             rotate: None,
             scale_x: Some(scale_based_on_height),
@@ -31,7 +34,7 @@ pub fn get_image_transform_for_page_size(
     let new_image_height = image_height * scale_based_on_width;
     ImageTransform {
         translate_x: Some(Mm(0.0)),
-        translate_y: Some(Mm((page_size_height - new_image_height) / 2.0)),
+        translate_y: Some((page_size_height - new_image_height) / 2.0),
         rotate: None,
         scale_x: Some(scale_based_on_width),
         scale_y: Some(scale_based_on_width),

--- a/src/image/image_x_object.rs
+++ b/src/image/image_x_object.rs
@@ -1,17 +1,10 @@
 use printpdf::{scale::Px, xobject::ImageXObject, Mm};
 
-fn pixel_to_mm(pixel: usize) -> Mm {
+fn pixel_to_mm(Px(pixel): Px) -> Mm {
     Mm((pixel as f64) * 0.084666667)
 }
 
 pub fn get_image_dimension_in_mm(image_object: &ImageXObject) -> (Mm, Mm) {
-    let ImageXObject {
-        width: Px(image_width_in_px),
-        height: Px(image_height_in_px),
-        ..
-    } = image_object;
-
-    let image_width = pixel_to_mm(*image_width_in_px);
-    let image_height = pixel_to_mm(*image_height_in_px);
-    (image_width, image_height)
+    let ImageXObject { width, height, .. } = image_object;
+    (pixel_to_mm(*width), pixel_to_mm(*height))
 }

--- a/src/image/image_x_object.rs
+++ b/src/image/image_x_object.rs
@@ -13,5 +13,5 @@ pub fn get_image_dimension_in_mm(image_object: &ImageXObject) -> (f64, f64) {
 
     let image_width = pixel_to_mm(*image_width_in_px);
     let image_height = pixel_to_mm(*image_height_in_px);
-    return (image_width, image_height);
+    (image_width, image_height)
 }

--- a/src/image/image_x_object.rs
+++ b/src/image/image_x_object.rs
@@ -1,10 +1,10 @@
-use printpdf::{scale::Px, xobject::ImageXObject};
+use printpdf::{scale::Px, xobject::ImageXObject, Mm};
 
-fn pixel_to_mm(pixel: usize) -> f64 {
-    (pixel as f64) * 0.084666667
+fn pixel_to_mm(pixel: usize) -> Mm {
+    Mm((pixel as f64) * 0.084666667)
 }
 
-pub fn get_image_dimension_in_mm(image_object: &ImageXObject) -> (f64, f64) {
+pub fn get_image_dimension_in_mm(image_object: &ImageXObject) -> (Mm, Mm) {
     let ImageXObject {
         width: Px(image_width_in_px),
         height: Px(image_height_in_px),

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -1,4 +1,4 @@
+pub mod alpha_remover;
+pub mod image_reader;
 pub mod image_transform;
 pub mod image_x_object;
-pub mod image_reader;
-pub mod alpha_remover;

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,8 +11,8 @@ use std::io::BufWriter;
 
 use args::Args;
 use image::{
-    alpha_remover::RemoveAlpha, image_x_object::get_image_dimension_in_mm,
-    image_reader::read_image_from_file, image_transform::get_image_transform_for_page_size,
+    alpha_remover::RemoveAlpha, image_reader::read_image_from_file,
+    image_transform::get_image_transform_for_page_size, image_x_object::get_image_dimension_in_mm,
 };
 use pagesize::PageSizeInMm;
 
@@ -27,10 +27,7 @@ fn main() {
         pagesize,
     } = args;
 
-    let page_size_option = match pagesize {
-        Some(s) => Some(PageSizeInMm::new(&s)),
-        None => None,
-    };
+    let page_size_option = pagesize.as_deref().map(PageSizeInMm::new);
 
     let doc = PdfDocument::empty("Random Document Title");
 
@@ -48,7 +45,7 @@ fn main() {
         };
         let (color_type, mut img) = img_result.unwrap();
         if let Some(page_size) = &page_size_option {
-            let image_transform = get_image_transform_for_page_size(&page_size, &img.image);
+            let image_transform = get_image_transform_for_page_size(page_size, &img.image);
             let PageSizeInMm(width, height) = page_size;
             let (page, layer_index) =
                 doc.add_page(Mm(width.to_owned()), Mm(height.to_owned()), "Layer1");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod args;
 mod image;
 mod pagesize;
 
+use anyhow::anyhow;
 use clap::Parser;
 use colored::*;
 use printpdf::{ImageTransform, Mm, PdfDocument};
@@ -16,71 +17,67 @@ use image::{
 };
 use pagesize::PageSizeInMm;
 
-const MIN_WIDTH_IN_MM: f64 = 210.0;
-const MIN_HEIGHT_IN_MM: f64 = 297.0;
+const MIN_WIDTH_IN_MM: Mm = Mm(210.0);
+const MIN_HEIGHT_IN_MM: Mm = Mm(297.0);
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args: Args = Args::parse();
+    println!("{:?}", args);
     let Args {
         input: input_img_files,
         output: output_pdf_file,
-        pagesize,
+        pagesize: pagesize_option,
     } = args;
-
-    let page_size_option = pagesize.as_deref().map(PageSizeInMm::new);
 
     let doc = PdfDocument::empty("Random Document Title");
 
-    input_img_files.iter().for_each(|img_file_name| {
-        let img_result = read_image_from_file(img_file_name);
-        if let Err(ref e) = img_result {
-            println!(
+    for img_file_name in input_img_files {
+        let (color_type, mut img) = read_image_from_file(&img_file_name).map_err(|e| {
+            anyhow!(
                 "{}: cannot read file {}. {}: {}",
                 "Warning".yellow(),
-                img_file_name.blue().underline(),
+                img_file_name.to_string_lossy().blue().underline(),
                 "Error".red(),
                 e
-            );
-            return;
-        };
-        let (color_type, mut img) = img_result.unwrap();
-        if let Some(page_size) = &page_size_option {
-            let image_transform = get_image_transform_for_page_size(page_size, &img.image);
-            let PageSizeInMm(width, height) = page_size;
-            let (page, layer_index) =
-                doc.add_page(Mm(width.to_owned()), Mm(height.to_owned()), "Layer1");
-            let current_layer = doc.get_page(page).get_layer(layer_index);
-            img.remove_alpha(color_type);
-            img.add_to_layer(current_layer.clone(), image_transform);
-        } else {
-            let (original_image_width, original_image_height) =
-                get_image_dimension_in_mm(&img.image);
+            )
+        })?;
+        match pagesize_option {
+            Some(pagesize @ PageSizeInMm { width, height }) => {
+                let image_transform = get_image_transform_for_page_size(pagesize, &img.image);
+                let (page, layer_index) = doc.add_page(width, height, "Layer1");
+                let current_layer = doc.get_page(page).get_layer(layer_index);
+                img.remove_alpha(color_type);
+                img.add_to_layer(current_layer.clone(), image_transform);
+            }
+            None => {
+                let (original_image_width, original_image_height) =
+                    get_image_dimension_in_mm(&img.image);
+                let image_scale = max(
+                    1,
+                    max(
+                        (MIN_WIDTH_IN_MM / original_image_width) as i32,
+                        (MIN_HEIGHT_IN_MM / original_image_height) as i32,
+                    ),
+                ) as f64;
+                let (page, layer_index) = doc.add_page(
+                    original_image_width * image_scale,
+                    original_image_height * image_scale,
+                    "Layer1",
+                );
+                let current_layer = doc.get_page(page).get_layer(layer_index);
+                img.remove_alpha(color_type);
+                img.add_to_layer(
+                    current_layer.clone(),
+                    ImageTransform {
+                        scale_x: Some(image_scale),
+                        scale_y: Some(image_scale),
+                        ..Default::default()
+                    },
+                );
+            }
+        }
+    }
 
-            let image_scale = max(
-                1,
-                max(
-                    (MIN_WIDTH_IN_MM / original_image_width) as i32,
-                    (MIN_HEIGHT_IN_MM / original_image_height) as i32,
-                ),
-            ) as f64;
-            let (page, layer_index) = doc.add_page(
-                Mm(original_image_width * image_scale),
-                Mm(original_image_height * image_scale),
-                "Layer1",
-            );
-            let current_layer = doc.get_page(page).get_layer(layer_index);
-            img.remove_alpha(color_type);
-            img.add_to_layer(
-                current_layer.clone(),
-                ImageTransform {
-                    scale_x: Some(image_scale),
-                    scale_y: Some(image_scale),
-                    ..Default::default()
-                },
-            );
-        };
-    });
-
-    doc.save(&mut BufWriter::new(File::create(output_pdf_file).unwrap()))
-        .unwrap();
+    doc.save(&mut BufWriter::new(File::create(output_pdf_file)?))?;
+    Ok(())
 }

--- a/src/pagesize.rs
+++ b/src/pagesize.rs
@@ -1,93 +1,140 @@
-use std::collections::HashMap;
+use std::str::FromStr;
 
+use anyhow::anyhow;
 use colored::*;
+use printpdf::Mm;
 use regex::Regex;
 
-// PageSizeInMm(width, height)
-#[derive(Debug, Clone)]
-pub struct PageSizeInMm(pub f64, pub f64);
-
-impl PageSizeInMm {
-    pub fn new(pagesize: &str) -> Self {
-        let pagesize = pagesize.to_lowercase().trim().to_string();
-        let pagesize = pagesize.as_str();
-        let page_size_map = HashMap::from([
-            ("a0", PageSizeInMm(841.0, 1189.0)),
-            ("a1", PageSizeInMm(594.0, 841.0)),
-            ("a2", PageSizeInMm(420.0, 594.0)),
-            ("a3", PageSizeInMm(297.0, 420.0)),
-            ("a4", PageSizeInMm(210.0, 297.0)),
-            ("a5", PageSizeInMm(148.0, 210.0)),
-            ("a6", PageSizeInMm(105.0, 148.0)),
-            ("b0", PageSizeInMm(1000.0, 1414.0)),
-            ("b1", PageSizeInMm(707.0, 1000.0)),
-            ("b2", PageSizeInMm(500.0, 707.0)),
-            ("b3", PageSizeInMm(353.0, 500.0)),
-            ("b4", PageSizeInMm(250.0, 353.0)),
-            ("b5", PageSizeInMm(176.0, 250.0)),
-            ("b6", PageSizeInMm(125.0, 176.0)),
-            ("jb0", PageSizeInMm(1030.0, 456.0)),
-            ("jb1", PageSizeInMm(728.0, 1030.0)),
-            ("jb2", PageSizeInMm(515.0, 728.0)),
-            ("jb3", PageSizeInMm(364.0, 515.0)),
-            ("jb4", PageSizeInMm(257.0, 364.0)),
-            ("jb5", PageSizeInMm(182.0, 257.0)),
-            ("jb6", PageSizeInMm(128.0, 182.0)),
-            ("letter", PageSizeInMm(215.9, 279.4)),
-            ("legal", PageSizeInMm(215.9, 355.6)),
-            ("tabloid", PageSizeInMm(279.4, 431.8)),
-        ]);
-
-        if page_size_map.contains_key(pagesize) {
-            return page_size_map.get(pagesize).unwrap().to_owned();
+macro_rules! page_size_formats {
+    ($($name:ident => ($str:literal, $width:literal, $height:literal)),* $(,)?) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum PageSizeFormat {
+            $($name),*
         }
 
-        if pagesize.ends_with("^t") {
-            let pdf_format = pagesize.split('^').next().unwrap();
-            if !page_size_map.contains_key(pdf_format) {
-                panic!(
-                    "PDF format {} is not recognized. Run {} to see valid pagesize value.",
-                    pdf_format.blue().underline(),
-                    "-h/--help".cyan()
-                );
-            };
-            return page_size_map.get(pdf_format).unwrap().invert();
+        impl FromStr for PageSizeFormat {
+            type Err = ();
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                match s.to_lowercase().trim().trim_end_matches("^t") {
+                    $($str => Ok(PageSizeFormat::$name),)*
+                    _ => Err(()),
+                }
+            }
+        }
+
+        impl PageSizeFormat {
+            pub fn to_page_size(self) -> PageSizeInMm {
+                match self {
+                    $(PageSizeFormat::$name => PageSizeInMm {
+                        width: Mm($width),
+                        height: Mm($height),
+                    }),*
+                }
+            }
+        }
+
+        impl From<PageSizeFormat> for PageSizeInMm {
+            #[inline(always)]
+            fn from(page_size_format: PageSizeFormat) -> Self {
+                page_size_format.to_page_size()
+            }
+        }
+    };
+}
+
+page_size_formats! {
+    A0 => ("a0", 841.0, 1189.0),
+    A1 => ("a1", 594.0, 841.0),
+    A2 => ("a2", 420.0, 594.0),
+    A3 => ("a3", 297.0, 420.0),
+    A4 => ("a4", 210.0, 297.0),
+    A5 => ("a5", 148.0, 210.0),
+    A6 => ("a6", 105.0, 148.0),
+    B0 => ("b0", 1000.0, 1414.0),
+    B1 => ("b1", 707.0, 1000.0),
+    B2 => ("b2", 500.0, 707.0),
+    B3 => ("b3", 353.0, 500.0),
+    B4 => ("b4", 250.0, 353.0),
+    B5 => ("b5", 176.0, 250.0),
+    B6 => ("b6", 125.0, 176.0),
+    Jb0 => ("jb0", 1030.0, 456.0),
+    Jb1 => ("jb1", 728.0, 1030.0),
+    Jb2 => ("jb2", 515.0, 728.0),
+    Jb3 => ("jb3", 364.0, 515.0),
+    Jb4 => ("jb4", 257.0, 364.0),
+    Jb5 => ("jb5", 182.0, 257.0),
+    Jb6 => ("jb6", 128.0, 182.0),
+    Letter => ("letter", 215.9, 279.4),
+    Legal => ("legal", 215.9, 355.6),
+    Tabloid => ("tabloid", 279.4, 431.8),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct PageSizeInMm {
+    pub width: Mm,
+    pub height: Mm,
+}
+
+impl PageSizeInMm {
+    pub fn invert(self) -> Self {
+        let PageSizeInMm { width, height } = self;
+        PageSizeInMm {
+            width: height,
+            height: width,
+        }
+    }
+}
+
+impl FromStr for PageSizeInMm {
+    type Err = anyhow::Error;
+
+    fn from_str(pagesize: &str) -> Result<Self, Self::Err> {
+        let pagesize = pagesize.to_lowercase();
+        let pagesize = pagesize.trim();
+        let pagesize_format = pagesize.parse::<PageSizeFormat>().ok();
+
+        if let Some(pagesize_format) = pagesize_format {
+            if pagesize.ends_with("^t") {
+                return Ok(pagesize_format.to_page_size().invert());
+            }
+            return Ok(pagesize_format.into());
         }
 
         let float_regex_str = r"\d+(\.\d+)?";
         let float_size_regex_str = format!("{}(?:mm|cm|in)", float_regex_str);
         let pagesize_regex_str = format!("^{}x{}$", float_size_regex_str, float_size_regex_str);
 
-        let customized_pagesize_regex = Regex::new(pagesize_regex_str.as_str()).unwrap();
+        let customized_pagesize_regex = Regex::new(&pagesize_regex_str).unwrap();
 
         if customized_pagesize_regex.is_match(pagesize) {
             let mut pagesize_split = pagesize.split('x');
             let width_str = pagesize_split.next().unwrap();
             let height_str = pagesize_split.next().unwrap();
 
-            let get_size_in_mm = |size_str: &str| {
-                let size_num = &size_str[..size_str.len() - 2].parse::<f64>().unwrap();
+            fn get_size_in_mm(size_str: &str) -> anyhow::Result<f64> {
+                let size_num = size_str[..size_str.len() - 2].parse::<f64>().unwrap();
                 let size_unit = &size_str[(size_str.len() - 2)..];
 
                 match size_unit {
-                    "mm" => *size_num,
-                    "cm" => size_num * 10.0,
-                    "in" => size_num * 25.4,
-                    _ => panic!("Invalid unit"),
+                    "mm" => Ok(size_num),
+                    "cm" => Ok(size_num * 10.0),
+                    "in" => Ok(size_num * 25.4),
+                    _ => Err(anyhow!(
+                        "Invalid unit `{size_unit}`. Possible units: `mm`, `cm` and `in`."
+                    )),
                 }
-            };
-            return PageSizeInMm(get_size_in_mm(width_str), get_size_in_mm(height_str));
+            }
+            return Ok(PageSizeInMm {
+                width: Mm(get_size_in_mm(width_str)?),
+                height: Mm(get_size_in_mm(height_str)?),
+            });
         }
 
-        panic!(
+        anyhow::bail!(
             "Pagesize value {} is invalid. Run {} to see valid pagesize value.",
             pagesize.blue().underline(),
             "-h/--help".cyan()
         );
-    }
-
-    pub fn invert(&self) -> Self {
-        let PageSizeInMm(width, height) = *self;
-        PageSizeInMm(height, width)
     }
 }

--- a/src/pagesize.rs
+++ b/src/pagesize.rs
@@ -43,7 +43,7 @@ impl PageSizeInMm {
         }
 
         if pagesize.ends_with("^t") {
-            let pdf_format = pagesize.split('^').nth(0).unwrap();
+            let pdf_format = pagesize.split('^').next().unwrap();
             if !page_size_map.contains_key(pdf_format) {
                 panic!(
                     "PDF format {} is not recognized. Run {} to see valid pagesize value.",


### PR DESCRIPTION
- Fix compilation error
- Update `clap` version
- Apply `cargo clippy` and `cargo fmt`
- Use enum and pattern matching instead of hashmap for page size format names
- Use `printpdf::scale::Mm` newtype for representation of millimeters in local types
- Add doc comments for `Args` fields, so that `--help`/`-h` would be more descriptive
- Add progress bars and spinners for visibility of progress (matters for large images, like manga pages)